### PR TITLE
packages/aflxx: init

### DIFF
--- a/packages/aflxx-nix/package.nix
+++ b/packages/aflxx-nix/package.nix
@@ -1,7 +1,7 @@
 {
   aflxx-stdenv,
   nix,
-  aflplusplus,
+  aflxx,
   makeSetupHook,
   writeText,
 }:
@@ -17,8 +17,8 @@ let
           preConfigurePhases+=" aflSetupPhase"
 
           aflSetupPhase() {
-            export CC=${aflplusplus}/bin/afl-gcc
-            export CXX=${aflplusplus}/bin/afl-g++
+            export CC=${aflxx}/bin/afl-clang-lto
+            export CXX=${aflxx}/bin/afl-clang-lto++
           }
         ''
       );

--- a/packages/aflxx-stdenv/package.nix
+++ b/packages/aflxx-stdenv/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   overrideCC,
-  aflplusplus,
+  aflxx,
   wrapCCWith,
   wrapBintoolsWith,
   binutils-unwrapped,
@@ -9,7 +9,7 @@
 }:
 let
   cc = wrapCCWith {
-    cc = aflplusplus;
+    cc = aflxx;
     bintools = wrapBintoolsWith {
       bintools = binutils-unwrapped;
       libc = glibc;

--- a/packages/aflxx/package.nix
+++ b/packages/aflxx/package.nix
@@ -1,0 +1,13 @@
+{
+  aflplusplus,
+  clang_19,
+  gcc14,
+  llvm_19,
+  llvmPackages_19,
+}:
+aflplusplus.override {
+  clang = clang_19;
+  gcc = gcc14;
+  llvm = llvm_19;
+  llvmPackages = llvmPackages_19;
+}


### PR DESCRIPTION
This adds a build of AFL++ using more recent clang / LLVM and GCC versions. This also enables to build C++20 projects like Nix. 

Furthermore, that new AFL++ is now used to build Nix, which enables usage of `afl-clang-lto(++)`, which - amongst other benefits - reports way more accurate coverage.

Closes #1 