### PR TITLE
ci: add flake update action

### DIFF
--- a/.github/workflow/nix-flake-update.yml
+++ b/.github/workflow/nix-flake-update.yml
@@ -1,0 +1,17 @@
+name: Update Flake Inputs
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: DeterminateSystems/nix-installer-action@e50d5f73bfe71c2dd0aa4218de8f4afa59f8f81d # v16
+      - uses: DeterminateSystems/update-flake-lock@a2bbe0274e3a0c4194390a1e445f734c597ebc37 # v24
+        with:
+          pr-title: Update Flake Inputs
+          pr-labels: dependencies
+          token: ${{ secrets.PR_TOKEN }}


### PR DESCRIPTION
This adds an action that automatically bumps the flake inputs (i.e. all dependencies) on a weekly basis.