### PR TITLE
packages/aflxx: enable persistent replay support

### DIFF
--- a/packages/aflxx/package.nix
+++ b/packages/aflxx/package.nix
@@ -1,13 +1,23 @@
 {
+  lib,
   aflplusplus,
   clang_19,
   gcc14,
   llvm_19,
   llvmPackages_19,
+  persistentReplay ? true,
 }:
-aflplusplus.override {
+(aflplusplus.override {
   clang = clang_19;
   gcc = gcc14;
   llvm = llvm_19;
   llvmPackages = llvmPackages_19;
-}
+}).overrideAttrs
+  (oldAttrs: {
+    postPatch =
+      oldAttrs.postPatch
+      + lib.optionalString persistentReplay ''
+        substituteInPlace include/config.h \
+          --replace-fail '// #define AFL_PERSISTENT_RECORD' '#define AFL_PERSISTENT_RECORD'
+      '';
+  })


### PR DESCRIPTION
This enables support of replaying persistent mode crashes by recording all test cases up until (and including) the crash. When testing, the `AFL_PERSISTENT_RECORD` environment variable needs to be set when starting `afl-fuzz` to enable this.